### PR TITLE
Definitive fix for execution order in post persist rules

### DIFF
--- a/src/Event/DelayedListener.php
+++ b/src/Event/DelayedListener.php
@@ -63,11 +63,20 @@ class DelayedListener
      */
     public function process(ModelInterface $model)
     {
-        foreach ($this->eventStack as $key => $event) {
+        $tmpStack = $this->eventStack;
+        $this->eventStack = [];
+        $eventStack = [];
+
+        foreach ($tmpStack as $event) {
             if (spl_object_hash($event->getSubject()) === spl_object_hash($model)) {
-                unset($this->eventStack[$key]);
-                \call_user_func($this->listener, $event);
+                $eventStack[] = $event;
+                continue;
             }
+            $this->eventStack[] = $event;
+        }
+
+        foreach ($eventStack as $key => $event) {
+            \call_user_func($this->listener, $event);
         }
     }
 


### PR DESCRIPTION
The order was not great if 2 events were in the stack. Here is a drawof the situation before the fix:

Init state: (event stack) [event1, event2]

On persist: (event stack loop) [event1, event2]
-> Execution event1 (event stack [event2])
    On persist (inside rule): (event stack loop) [event2]
    -> Execution event2
Loop continue
-> Execution event2

Conclusion: 3 events executed for a stack of 2 events.
Fixed by extracting events from the event stack before looping.