### PR TITLE
Fix implementation of 2 interfaces not working

### DIFF
--- a/Tests/fixtures/FakeModel.php
+++ b/Tests/fixtures/FakeModel.php
@@ -58,6 +58,7 @@ class FakeModel implements \Biig\Component\Domain\Model\ModelInterface
      */
     public function doAction()
     {
+        $this->dispatch('previous_action',  new \Biig\Component\Domain\Event\DomainEvent($this));
         $this->dispatch('action', new \Biig\Component\Domain\Event\DomainEvent($this));
     }
 }

--- a/src/Event/DomainEventDispatcher.php
+++ b/src/Event/DomainEventDispatcher.php
@@ -35,11 +35,11 @@ class DomainEventDispatcher extends EventDispatcher
 
         if ($rule instanceof DomainRuleInterface) {
             $this->addDomainRule($rule);
-
-            return;
         }
 
-        $this->addPostPersistDomainRuleInterface($rule);
+        if ($rule instanceof PostPersistDomainRuleInterface) {
+            $this->addPostPersistDomainRuleInterface($rule);
+        }
     }
 
     /**


### PR DESCRIPTION
The implementation of DomainRuleInterface and PostpersistRuleInterface at the same time is fixed by this commit.