### PR TITLE
Add alias for domain dispatcher classname

### DIFF
--- a/src/Integration/Symfony/Resources/config/services.yaml
+++ b/src/Integration/Symfony/Resources/config/services.yaml
@@ -2,6 +2,8 @@ services:
     biig_domain.dispatcher:
         class: Biig\Component\Domain\Event\DomainEventDispatcher
 
+    Biig\Component\Domain\Event\DomainEventDispatcher: '@biig_domain.dispatcher'
+
     Biig\Component\Domain\Model\Instantiator\Instantiator:
         arguments:
             - "@biig_domain.dispatcher"


### PR DESCRIPTION
The goal of this PR is to add a new feature so you can declare service like that in Symfony so they are autowired:

```php
class DomainModelFactory
{
    /**
     * @var DomainEventDispatcher
     */
    private $domainDispatcher;

    public function __construct(DomainEventDispatcher $dispatcher)
    {
        $this->domainDispatcher = $dispatcher;
    }
}
```

By the way. Push button ❤️  if you want to see this class inside the project. I think it's useful.