### PR TITLE
Instantiate with static factory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
     - 7.1
     - 7.2
+    - 7.3
 
 branches:
     only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Add support for static factories in domain model instantiator
 
 ## [1.4.4] - 2018-11-08
 ### Added

--- a/Tests/Model/Instantiator/InstantiatorTest.php
+++ b/Tests/Model/Instantiator/InstantiatorTest.php
@@ -5,6 +5,7 @@ namespace Biig\Component\Domain\Tests\Model\Instantiator;
 require_once __DIR__ . '/../../fixtures/FakeModel.php';
 
 use Biig\Component\Domain\Event\DomainEventDispatcher;
+use Biig\Component\Domain\Model\DomainModel;
 use Biig\Component\Domain\Model\Instantiator\DomainModelInstantiatorInterface;
 use Biig\Component\Domain\Model\Instantiator\Instantiator;
 use PHPUnit\Framework\TestCase;
@@ -49,6 +50,22 @@ class InstantiatorTest extends TestCase
     {
         $this->assertInstanceOf(DomainModelInstantiatorInterface::class, $this->instantiator);
     }
+
+    public function testItInstanciateViaStaticFactory()
+    {
+        $model = $this->instantiator->instantiateViaStaticFactory(DummyObjectWithStaticFactoryConstructor::class, 'createFooWithHello');
+        $this->assertInstanceOf(DummyObjectWithStaticFactoryConstructor::class, $model);
+        $this->assertTrue($model->hasDispatcher());
+        $this->assertEquals('hello', $model->getFoo());
+    }
+
+    public function testItInstanciateViaStaticFactoryWithArgs()
+    {
+        $model = $this->instantiator->instantiateViaStaticFactory(DummyObjectWithStaticFactoryConstructor::class, 'createFoo', 'world');
+        $this->assertInstanceOf(DummyObjectWithStaticFactoryConstructor::class, $model);
+        $this->assertTrue($model->hasDispatcher());
+        $this->assertEquals('world', $model->getFoo());
+    }
 }
 
 class FakeSimpleModel
@@ -67,5 +84,40 @@ class DummyObjectWithConstructor
     public function getFoo()
     {
         return $this->foo;
+    }
+}
+
+class DummyObjectWithStaticFactoryConstructor implements \Biig\Component\Domain\Model\ModelInterface
+{
+    use \Biig\Component\Domain\Model\DomainModelTrait;
+    private $foo;
+
+    private function __construct(string $foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function hasDispatcher()
+    {
+        return null !== $this->dispatcher;
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public static function createFoo($foo)
+    {
+        $dummy = new self($foo);
+
+        return $dummy;
+    }
+
+    public static function createFooWithHello()
+    {
+        $dummy = new self('hello');
+
+        return $dummy;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
+        "php": ">=7.1",
         "symfony/event-dispatcher": "~3.3|~4.0"
     },
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "phpunit/phpunit": "^6.4",
         "doctrine/orm": "^2.5",
         "symfony/symfony": "~3.3|~4.0",
-        "friendsofphp/php-cs-fixer": "^2.8",
+        "friendsofphp/php-cs-fixer": "^2.14",
         "doctrine/doctrine-bundle": "^1.8"
     },
     "autoload": {

--- a/src/Model/Instantiator/Instantiator.php
+++ b/src/Model/Instantiator/Instantiator.php
@@ -39,6 +39,14 @@ class Instantiator implements DomainModelInstantiatorInterface
         return $object;
     }
 
+    public function instantiateViaStaticFactory(string $className, string $factoryMethodName, ...$args)
+    {
+        $object = $className::$factoryMethodName(...$args);
+        $this->injectDispatcher($object);
+
+        return $object;
+    }
+
     protected function injectDispatcher($object)
     {
         if ($object instanceof ModelInterface) {


### PR DESCRIPTION
Helps you instantiate objects with static factories and dispatcher inside.

Because static factories for domain models are a good practice.