### PR TITLE
Removed backward compatibility layer for Sf < 4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [2.0.3] - 2019-07-25
+### Changed
+- Removed BC layer for Sf < 4.3 (was useless)
+
 ## [2.0.2] - 2019-07-08
 ### Changed
 

--- a/src/Event/DomainEventDispatcher.php
+++ b/src/Event/DomainEventDispatcher.php
@@ -80,13 +80,13 @@ final class DomainEventDispatcher extends EventDispatcher implements DomainEvent
     }
 
     /**
-     * @param Event|null $event
+     * @param Event|null  $event
+     * @param string|null $eventName
      *
      * @return Event
      */
-    public function dispatch($event/*, string $eventName = null*/)
+    public function dispatch($event, string $eventName = null)
     {
-        $eventName = 1 < \func_num_args() ? \func_get_arg(1) : null;
         $event = parent::dispatch($event, $eventName);
 
         if ($event instanceof DomainEvent) {


### PR DESCRIPTION
This was triggering deprecation notice while using it.

Also it makes no sense to have a compatibility layer for Sf < 4.3
while we're not even supporting those versions. If you need a version
that supports backward compatibility, please use DomainComponent 1.x.