### PR TITLE
Add doctrine bundle in dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "require": {
         "php": ">=7.1",
         "symfony/event-dispatcher": "^4.3|^5.0",
+        "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "^2.6.3"
     },
     "authors": [
@@ -17,7 +18,6 @@
         "phpunit/phpunit": "^6.4",
         "doctrine/orm": "^2.6.3",
         "friendsofphp/php-cs-fixer": "^2.14",
-        "doctrine/doctrine-bundle": "^1.8",
         "symfony/symfony": "^4.3|^5.0"
     },
     "conflict": {


### PR DESCRIPTION
This is a requirement in order to make the Symfony Recipe work. Of course it's sad because the library will enforce the installation of the doctrine bundle. But at this moment I don't think anybody installed this library without Symfony and the Doctrine bundle. Also the bundle present in our bridge is dependent of the Symfony Doctrine Bundle.

Taking all of this, I think it's not a bad thing and we will reconsider if it's a problem some day.

Related to https://github.com/biig-io/DomainComponent/issues/62 and https://github.com/symfony/recipes-contrib/pull/763

WDYT?