### PR TITLE
Load Rules lazyly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php": ">=7.1",
         "symfony/event-dispatcher": "^4.3|^5.0",
-        "doctrine/orm": "^2.6.3"
+        "doctrine/orm": "^2.6.3",
+        "symfony/proxy-manager-bridge": "^4.4"
     },
     "authors": [
         {

--- a/src/Integration/Symfony/DependencyInjection/CompilerPass/RegisterDomainRulesCompilerPass.php
+++ b/src/Integration/Symfony/DependencyInjection/CompilerPass/RegisterDomainRulesCompilerPass.php
@@ -27,6 +27,7 @@ class RegisterDomainRulesCompilerPass implements CompilerPassInterface
                     $this->addListenerForEventsInDefinition($id, $class, $attribute, $definition);
                 }
             } else {
+                $def->setLazy(true);
                 $definition->addMethodCall('addRule', [
                     new Reference($id),
                 ]);

--- a/src/Rule/DomainRuleInterface.php
+++ b/src/Rule/DomainRuleInterface.php
@@ -9,5 +9,5 @@ interface DomainRuleInterface extends RuleInterface
      *
      * @return array|string
      */
-    public function on();
+    public static function on();
 }

--- a/src/Rule/PostPersistDomainRuleInterface.php
+++ b/src/Rule/PostPersistDomainRuleInterface.php
@@ -15,5 +15,5 @@ interface PostPersistDomainRuleInterface extends RuleInterface
      *
      * @return array|string
      */
-    public function after();
+    public static function after();
 }


### PR DESCRIPTION
Use proxy manager to proxify Rules.

Rules should not be loaded with all dependent services at each start of the application. 
Who knows how many services are injected by Rules ?
Instead, set each Rule as a lazy service.

BUT, the downside is that I put `on` and `after` functions as `static` to be able to get events without initialize the Rule object.
So it comes with less flexibility, as you cannot define complex behaviour in `on` and `after` functions.
Oh, and it breaks compatibility, obviously.

Another (better ?) idea would be to split detection and execution in 2 classes.
One `Rule` with `on` or/and `after` function and on `Handler` with one function `handle` which will execute what needs to be executed.
And only the Handler would be set as lazy.
BUT, the downside is that one would have to implement two classes instead of one ...