### PR TITLE
Update use event dispatcher so as not to break TraceableEventDispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpunit/phpunit": "^6.4",
         "doctrine/orm": "^2.6.3",
         "friendsofphp/php-cs-fixer": "^2.14",
-        "symfony/symfony": "^4.3|^5.0"
+        "symfony/symfony": "^4.3"
     },
     "conflict": {
         "doctrine/orm": "<2.6.3"

--- a/src/Event/DomainEventDispatcherInterface.php
+++ b/src/Event/DomainEventDispatcherInterface.php
@@ -5,7 +5,7 @@ namespace Biig\Component\Domain\Event;
 use Biig\Component\Domain\Model\ModelInterface;
 use Biig\Component\Domain\Rule\DomainRuleInterface;
 use Biig\Component\Domain\Rule\PostPersistDomainRuleInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 interface DomainEventDispatcherInterface extends EventDispatcherInterface
 {


### PR DESCRIPTION
When a dispatcher which extends `DomainEventDispatcherInterface` and it pass into `Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher`, an error is returned because the 1st argument is `Symfony\Component\EventDispatcher\EventDispatcherInterface`